### PR TITLE
Add Linux Intel GPU inference with OpenVINO

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+target
+models/*.onnx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ ort = { version = "2.0.0-rc.13", default-features = false, features = [
     "coreml",
     "ndarray",
     "load-dynamic",
+    "openvino",
 ] }
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ authors = ["Blue Onyx Team"]
 license = "MIT"
 homepage = "https://github.com/blue-onyx/blue-onyx"
 
+[features]
+default = []
+openvino = ["ort/openvino"]
+
 [dependencies]
 
 ab_glyph = { version = "0", default-features = false, features = ["std"] }
@@ -83,7 +87,6 @@ ort = { version = "2.0.0-rc.13", default-features = false, features = [
     "coreml",
     "ndarray",
     "load-dynamic",
-    "openvino",
 ] }
 
 [target.'cfg(windows)'.dependencies]

--- a/Dockerfile.openvino
+++ b/Dockerfile.openvino
@@ -1,11 +1,55 @@
-FROM python:3.11-slim-bookworm AS onnxruntime
+ARG OPENVINO_VERSION=2026.2.1
+ARG ONNXRUNTIME_VERSION=1.29.0
 
-ARG ONNXRUNTIME_OPENVINO_VERSION=1.22.0
-RUN python -m pip install --no-cache-dir --target /opt/ort \
-    "onnxruntime-openvino==${ONNXRUNTIME_OPENVINO_VERSION}" && \
-    mkdir /opt/ort-libs && \
-    cp -a /opt/ort/onnxruntime/capi/lib*.so* /opt/ort-libs/ && \
-    ln -s libonnxruntime.so.1.22.0 /opt/ort-libs/libonnxruntime.so
+FROM openvino/ubuntu24_runtime:${OPENVINO_VERSION} AS onnxruntime
+
+ARG ONNXRUNTIME_VERSION
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential ca-certificates curl git libprotobuf-dev protobuf-compiler \
+        python3-dev python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install --no-cache-dir --upgrade \
+    cmake flatbuffers mypy numpy onnx onnxscript protobuf psutil pytest \
+    setuptools sympy wheel
+
+WORKDIR /opt
+RUN curl -fsSL \
+        "https://github.com/microsoft/onnxruntime/archive/refs/tags/v${ONNXRUNTIME_VERSION}.zip" \
+        -o /tmp/onnxruntime.zip && \
+    python3 -m zipfile -e /tmp/onnxruntime.zip /opt && \
+    mv "onnxruntime-${ONNXRUNTIME_VERSION}" onnxruntime && \
+    rm /tmp/onnxruntime.zip
+
+WORKDIR /opt/onnxruntime
+# ORT 1.29's OpenVINO provider omits two required standard-library headers.
+RUN sed -i '1i#include <charconv>' \
+        onnxruntime/core/providers/openvino/backend_manager.cc \
+        onnxruntime/core/providers/openvino/exceptions.h && \
+    sed -i '1i#include <optional>' \
+        onnxruntime/core/providers/openvino/ov_bin_manager.h \
+        onnxruntime/core/providers/openvino/ov_shared_context.h
+RUN bash ./build.sh \
+    --allow_running_as_root \
+    --config Release \
+    --update \
+    --build \
+    --parallel \
+    --compile_no_warning_as_error \
+    --skip_submodule_sync \
+    --skip_tests \
+    --no_telemetry \
+    --enable_lto \
+    --disable_contrib_ops \
+    --use_openvino GPU \
+    --build_shared_lib \
+    --cmake_extra_defines \
+        onnxruntime_BUILD_UNIT_TESTS=OFF \
+        CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        FETCHCONTENT_TRY_FIND_PACKAGE_MODE=NEVER && \
+    mkdir -p /opt/ort-libs && \
+    cp -a build/Linux/Release/libonnxruntime*.so* /opt/ort-libs/
 
 FROM rust:bookworm AS builder
 
@@ -15,18 +59,17 @@ RUN apt-get update && \
 
 WORKDIR /src
 COPY . .
-COPY --from=onnxruntime /opt/ort-libs/libonnxruntime.so.1.22.0 \
-    /opt/ort-libs/libonnxruntime.so
+COPY --from=onnxruntime /opt/ort-libs /opt/ort-libs
 ENV BLUE_ONYX_ORT_LIB_DIR=/opt/ort-libs
 RUN cargo build --locked --release --bin blue_onyx --features openvino
 
-FROM openvino/ubuntu22_runtime:2025.4.1
+FROM openvino/ubuntu24_runtime:${OPENVINO_VERSION}
 
 LABEL org.opencontainers.image.title="Blue Onyx OpenVINO"
 LABEL org.opencontainers.image.source="https://github.com/xnorpx/blue-onyx"
 LABEL org.opencontainers.image.description="Blue Onyx with Linux OpenVINO GPU inference"
 
-ENV LD_LIBRARY_PATH=/app/ort-libs
+ENV LD_LIBRARY_PATH=/app/ort-libs:${LD_LIBRARY_PATH}
 ENV ORT_DYLIB_PATH=/app/ort-libs/libonnxruntime.so
 ENV BLUE_ONYX_OPENVINO_CACHE_DIR=/app/config/openvino-cache
 

--- a/Dockerfile.openvino
+++ b/Dockerfile.openvino
@@ -7,19 +7,6 @@ RUN python -m pip install --no-cache-dir --target /opt/ort \
     cp -a /opt/ort/onnxruntime/capi/lib*.so* /opt/ort-libs/ && \
     ln -s libonnxruntime.so.1.22.0 /opt/ort-libs/libonnxruntime.so
 
-FROM debian:bookworm-slim AS model
-
-ARG MODEL_SHA256=3b338be21f271a2924051fc237086a03c49daecd7e0fb2a8e97411ea5a33c6dc
-ARG MODEL_URL=https://huggingface.co/xnorpx/blue-onyx-yolo5/resolve/main/IPcam-general.onnx
-ARG MODEL_METADATA_URL=https://huggingface.co/xnorpx/blue-onyx-yolo5/resolve/main/IPcam-general.yaml
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl && \
-    mkdir /model && \
-    curl --fail --location --retry 3 "$MODEL_URL" --output /model/IPcam-general.onnx && \
-    curl --fail --location --retry 3 "$MODEL_METADATA_URL" --output /model/IPcam-general.yaml && \
-    echo "$MODEL_SHA256  /model/IPcam-general.onnx" | sha256sum --check && \
-    rm -rf /var/lib/apt/lists/*
-
 FROM rust:bookworm AS builder
 
 RUN apt-get update && \
@@ -31,7 +18,7 @@ COPY . .
 COPY --from=onnxruntime /opt/ort-libs/libonnxruntime.so.1.22.0 \
     /opt/ort-libs/libonnxruntime.so
 ENV BLUE_ONYX_ORT_LIB_DIR=/opt/ort-libs
-RUN cargo build --locked --release --bin blue_onyx
+RUN cargo build --locked --release --bin blue_onyx --features openvino
 
 FROM openvino/ubuntu22_runtime:2025.4.1
 
@@ -41,7 +28,7 @@ LABEL org.opencontainers.image.description="Blue Onyx with Linux OpenVINO GPU in
 
 ENV LD_LIBRARY_PATH=/app/ort-libs
 ENV ORT_DYLIB_PATH=/app/ort-libs/libonnxruntime.so
-ENV TARGET_FOLDER=/models
+ENV BLUE_ONYX_OPENVINO_CACHE_DIR=/app/config/openvino-cache
 
 USER root
 RUN mkdir -p /app/config/openvino-cache && \
@@ -50,7 +37,6 @@ RUN mkdir -p /app/config/openvino-cache && \
 WORKDIR /app
 COPY --from=builder --chown=openvino:openvino /src/target/release/blue_onyx ./blue_onyx
 COPY --from=onnxruntime --chown=openvino:openvino /opt/ort-libs ./ort-libs
-COPY --from=model --chown=openvino:openvino /model/IPcam-general.* ./
 
 USER openvino
 EXPOSE 32168

--- a/Dockerfile.openvino
+++ b/Dockerfile.openvino
@@ -1,0 +1,57 @@
+FROM python:3.11-slim-bookworm AS onnxruntime
+
+ARG ONNXRUNTIME_OPENVINO_VERSION=1.22.0
+RUN python -m pip install --no-cache-dir --target /opt/ort \
+    "onnxruntime-openvino==${ONNXRUNTIME_OPENVINO_VERSION}" && \
+    mkdir /opt/ort-libs && \
+    cp -a /opt/ort/onnxruntime/capi/lib*.so* /opt/ort-libs/ && \
+    ln -s libonnxruntime.so.1.22.0 /opt/ort-libs/libonnxruntime.so
+
+FROM debian:bookworm-slim AS model
+
+ARG MODEL_SHA256=3b338be21f271a2924051fc237086a03c49daecd7e0fb2a8e97411ea5a33c6dc
+ARG MODEL_URL=https://huggingface.co/xnorpx/blue-onyx-yolo5/resolve/main/IPcam-general.onnx
+ARG MODEL_METADATA_URL=https://huggingface.co/xnorpx/blue-onyx-yolo5/resolve/main/IPcam-general.yaml
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    mkdir /model && \
+    curl --fail --location --retry 3 "$MODEL_URL" --output /model/IPcam-general.onnx && \
+    curl --fail --location --retry 3 "$MODEL_METADATA_URL" --output /model/IPcam-general.yaml && \
+    echo "$MODEL_SHA256  /model/IPcam-general.onnx" | sha256sum --check && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM rust:bookworm AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends pkg-config libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+COPY --from=onnxruntime /opt/ort-libs/libonnxruntime.so.1.22.0 \
+    /opt/ort-libs/libonnxruntime.so
+ENV BLUE_ONYX_ORT_LIB_DIR=/opt/ort-libs
+RUN cargo build --locked --release --bin blue_onyx
+
+FROM openvino/ubuntu22_runtime:2025.4.1
+
+LABEL org.opencontainers.image.title="Blue Onyx OpenVINO"
+LABEL org.opencontainers.image.source="https://github.com/xnorpx/blue-onyx"
+LABEL org.opencontainers.image.description="Blue Onyx with Linux OpenVINO GPU inference"
+
+ENV LD_LIBRARY_PATH=/app/ort-libs
+ENV ORT_DYLIB_PATH=/app/ort-libs/libonnxruntime.so
+ENV TARGET_FOLDER=/models
+
+USER root
+RUN mkdir -p /app/config/openvino-cache && \
+    chown -R openvino:openvino /app
+
+WORKDIR /app
+COPY --from=builder --chown=openvino:openvino /src/target/release/blue_onyx ./blue_onyx
+COPY --from=onnxruntime --chown=openvino:openvino /opt/ort-libs ./ort-libs
+COPY --from=model --chown=openvino:openvino /model/IPcam-general.* ./
+
+USER openvino
+EXPOSE 32168
+ENTRYPOINT ["./blue_onyx"]

--- a/OPENVINO.md
+++ b/OPENVINO.md
@@ -1,0 +1,26 @@
+# Linux OpenVINO build
+
+This branch enables Blue Onyx GPU inference through the ONNX Runtime OpenVINO
+execution provider. It targets Intel GPU device `GPU.<gpu-index>`, uses FP16,
+one latency-focused stream, and stores compiled-model data under
+`/app/config/openvino-cache`.
+
+Build the image with:
+
+```sh
+docker build -f Dockerfile.openvino -t blue-onyx-openvino:0.8.0-openvino2 .
+```
+
+The container requires the Intel render device:
+
+```sh
+docker run --device /dev/dri/renderD128:/dev/dri/renderD128 \
+  blue-onyx-openvino:0.8.0-openvino2
+```
+
+Pass `--force-cpu` to retain the upstream CPU execution path.
+
+The deployed image is tagged `blue-onyx-openvino:0.8.0-openvino2`. Its
+production Compose definition is stored in `deployment/docker-compose.yml`.
+The container runs as UID/GID 1000 to remain compatible with the existing
+Blue Onyx bind-mounted configuration and log directories.

--- a/OPENVINO.md
+++ b/OPENVINO.md
@@ -4,6 +4,10 @@ This build enables Blue Onyx GPU inference through the ONNX Runtime OpenVINO
 execution provider. It targets Intel GPU device `GPU.<gpu-index>`, uses FP16,
 and uses one latency-focused stream. OpenVINO support is opt-in through the
 `openvino` Cargo feature, so standard Linux builds retain CPU inference.
+The image builds ONNX Runtime 1.29.0 with its OpenVINO provider against
+OpenVINO 2026.2.1 on Ubuntu 24.04, matching the ONNX Runtime version used by
+upstream. ONNX Runtime 1.29 requires a C++20 standard library with
+`std::format`; native source builds therefore require GCC 13 or newer.
 
 Build the image with:
 

--- a/OPENVINO.md
+++ b/OPENVINO.md
@@ -1,6 +1,6 @@
 # Linux OpenVINO build
 
-This branch enables Blue Onyx GPU inference through the ONNX Runtime OpenVINO
+This build enables Blue Onyx GPU inference through the ONNX Runtime OpenVINO
 execution provider. It targets Intel GPU device `GPU.<gpu-index>`, uses FP16,
 and uses one latency-focused stream. OpenVINO support is opt-in through the
 `openvino` Cargo feature, so standard Linux builds retain CPU inference.

--- a/OPENVINO.md
+++ b/OPENVINO.md
@@ -2,8 +2,8 @@
 
 This branch enables Blue Onyx GPU inference through the ONNX Runtime OpenVINO
 execution provider. It targets Intel GPU device `GPU.<gpu-index>`, uses FP16,
-one latency-focused stream, and stores compiled-model data under
-`/app/config/openvino-cache`.
+and uses one latency-focused stream. OpenVINO support is opt-in through the
+`openvino` Cargo feature, so standard Linux builds retain CPU inference.
 
 Build the image with:
 
@@ -20,7 +20,9 @@ docker run --device /dev/dri/renderD128:/dev/dri/renderD128 \
 
 Pass `--force-cpu` to retain the upstream CPU execution path.
 
-The deployed image is tagged `blue-onyx-openvino:0.8.0-openvino2`. Its
-production Compose definition is stored in `deployment/docker-compose.yml`.
-The container runs as UID/GID 1000 to remain compatible with the existing
-Blue Onyx bind-mounted configuration and log directories.
+Set `BLUE_ONYX_OPENVINO_CACHE_DIR` to enable the compiled-model cache. The
+OpenVINO Docker image sets it to `/app/config/openvino-cache`.
+
+The example image is tagged `blue-onyx-openvino:0.8.0-openvino2`. Its Compose
+definition is stored in `deployment/docker-compose.yml`. The container runs as
+UID/GID 1000 for bind-mounted configuration and log directories.

--- a/README.md
+++ b/README.md
@@ -92,10 +92,7 @@ docker run -d \
   -p 32168:32168 \
   -v "$(pwd)/config:/app/config" \
   -v "$(pwd)/logs:/app/logs" \
-  blue-onyx-openvino:0.8.0-openvino2 \
-  --model /app/IPcam-general.onnx \
-  --object-detection-model-type yolo5 \
-  --object-classes /app/IPcam-general.yaml
+  blue-onyx-openvino:0.8.0-openvino2
 ```
 
 Alternatively, use the included Compose deployment:

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ Confirm that the render device exists:
 ls -l /dev/dri/renderD128
 ```
 
-Build the OpenVINO image from the `openvino-linux` branch:
+Build the OpenVINO image from the repository:
 
 ```bash
-git clone --branch openvino-linux https://github.com/slflowfoon/blue-onyx.git
+git clone https://github.com/xnorpx/blue-onyx.git
 cd blue-onyx
 docker build -f Dockerfile.openvino -t blue-onyx-openvino:0.8.0-openvino2 .
 mkdir -p config logs

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Current features:
 | CPU Inference                               | 🟢             | 🟢           | 🟢          |
 | Apple GPU / Neural Engine Inference         | ❌             | ❌           | 🟢          |
 | AMD GPU Inference                           | 🟢             | ❌           | ❌          |
-| Intel GPU Inference                         | 🟢             | ❌           | ❌          |
+| Intel GPU Inference                         | 🟢             | 🟢 OpenVINO  | ❌          |
 | Nvidia GPU Inference                        | 🟢             | ❌           | ❌          |
 | Coral TPU Inference                         | ❌             | ❌           | ❌          |
 
@@ -47,10 +47,70 @@ Verify it is working by going to http://127.0.0.1:32168/
 
 ## Docker container on Linux
 
+### CPU
+
 ```bash
 docker pull ghcr.io/xnorpx/blue_onyx:latest
 docker run -d -p 32168:32168 ghcr.io/xnorpx/blue_onyx:latest
 ```
+
+### Intel GPU with OpenVINO
+
+The OpenVINO build accelerates inference on Intel integrated and discrete GPUs.
+It uses the ONNX Runtime OpenVINO execution provider with FP16 precision and a
+compiled-model cache. AMD and Nvidia GPU inference are not provided by this
+build.
+
+Requirements:
+
+- Linux x86_64 with a supported Intel GPU and working Intel graphics driver
+- The GPU render device available as `/dev/dri/renderD128`
+- Docker access to the render device
+
+Confirm that the render device exists:
+
+```bash
+ls -l /dev/dri/renderD128
+```
+
+Build the OpenVINO image from the `openvino-linux` branch:
+
+```bash
+git clone --branch openvino-linux https://github.com/slflowfoon/blue-onyx.git
+cd blue-onyx
+docker build -f Dockerfile.openvino -t blue-onyx-openvino:0.8.0-openvino2 .
+mkdir -p config logs
+sudo chown -R 1000:1000 config logs
+```
+
+Run it with the Intel render device passed through:
+
+```bash
+docker run -d \
+  --name blue-onyx \
+  --device /dev/dri/renderD128:/dev/dri/renderD128 \
+  -p 32168:32168 \
+  -v "$(pwd)/config:/app/config" \
+  -v "$(pwd)/logs:/app/logs" \
+  blue-onyx-openvino:0.8.0-openvino2 \
+  --model /app/IPcam-general.onnx \
+  --object-detection-model-type yolo5 \
+  --object-classes /app/IPcam-general.yaml
+```
+
+Alternatively, use the included Compose deployment:
+
+```bash
+docker compose -f deployment/docker-compose.yml up -d
+```
+
+Open `http://localhost:32168/stats` and confirm that **Execution Provider** is
+`OpenVINO(GPU 0)`. Use `--gpu-index N` to select another Intel GPU. Pass
+`--force-cpu` to use CPU inference instead.
+
+If the container cannot open the render device, grant the container user access
+through the host's `render` group or adjust the device permissions. See
+[OPENVINO.md](OPENVINO.md) for implementation and deployment details.
 
 ## macOS on Apple Silicon
 

--- a/build.rs
+++ b/build.rs
@@ -51,18 +51,32 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed=BLUE_ONYX_ORT_LIB_DIR");
     if let Ok(prebuilt_dir) = env::var("BLUE_ONYX_ORT_LIB_DIR") {
-        let library = Path::new(&prebuilt_dir).join("libonnxruntime.so");
+        let prebuilt_dir = Path::new(&prebuilt_dir);
+        let library = prebuilt_dir.join("libonnxruntime.so");
         if !library.is_file() {
             build_error!("Prebuilt ONNX Runtime library not found: {:?}", library);
             panic!("Prebuilt ONNX Runtime setup incomplete");
         }
+        if cfg!(all(target_os = "linux", feature = "openvino")) {
+            for name in [
+                "libonnxruntime_providers_shared.so",
+                "libonnxruntime_providers_openvino.so",
+            ] {
+                if !prebuilt_dir.join(name).is_file() {
+                    build_error!("Prebuilt ONNX Runtime provider library not found: {name}");
+                    panic!("Prebuilt ONNX Runtime OpenVINO setup incomplete");
+                }
+            }
+        }
 
-        build_warning!("Using prebuilt ONNX Runtime from {}", prebuilt_dir);
+        build_warning!(
+            "Using prebuilt ONNX Runtime from {}",
+            prebuilt_dir.display()
+        );
         if !output_dir.exists() {
             std::fs::create_dir_all(&output_dir).expect("Failed to create output directory");
         }
-        std::fs::copy(&library, output_dir.join("libonnxruntime.so"))
-            .expect("Failed to copy prebuilt ONNX Runtime library to output directory");
+        copy_onnxruntime_libraries(prebuilt_dir, &output_dir);
         println!("cargo:rustc-env=ORT_DYLIB_PATH=libonnxruntime.so");
         return;
     }
@@ -118,8 +132,12 @@ fn main() {
         std::fs::create_dir_all(&output_dir).expect("Failed to create output directory");
     }
 
-    std::fs::copy(&expected_binary, output_dir.join(shared_lib_name))
-        .expect("Failed to copy ONNX Runtime binary to output directory");
+    copy_onnxruntime_libraries(
+        expected_binary
+            .parent()
+            .expect("Expected ONNX Runtime binary must have a parent directory"),
+        &output_dir,
+    );
 
     // On Windows, also copy DirectML.dll to the output directory if it does not exist
     if cfg!(windows) {
@@ -135,6 +153,34 @@ fn main() {
     }
 
     println!("cargo:rustc-env=ORT_DYLIB_PATH={shared_lib_name}");
+}
+
+fn copy_onnxruntime_libraries(source_dir: &Path, output_dir: &Path) {
+    let mut copied = 0;
+    for entry in
+        std::fs::read_dir(source_dir).expect("Failed to read ONNX Runtime library directory")
+    {
+        let entry = entry.expect("Failed to read ONNX Runtime library entry");
+        let file_name = entry.file_name();
+        let Some(file_name_str) = file_name.to_str() else {
+            continue;
+        };
+        if !file_name_str.starts_with("libonnxruntime") && file_name_str != "onnxruntime.dll" {
+            continue;
+        }
+        let file_type = entry
+            .file_type()
+            .expect("Failed to inspect ONNX Runtime library entry");
+        if !file_type.is_file() && !file_type.is_symlink() {
+            continue;
+        }
+        std::fs::copy(entry.path(), output_dir.join(&file_name))
+            .expect("Failed to copy ONNX Runtime library to output directory");
+        copied += 1;
+    }
+    if copied == 0 {
+        panic!("No ONNX Runtime libraries were copied to the output directory");
+    }
 }
 
 fn cargo_output_dirs(out_dir: &str) -> (PathBuf, PathBuf) {
@@ -409,6 +455,10 @@ fn build_onnx(out_dir: &Path) {
         panic!("ONNX Runtime build script missing");
     }
 
+    if cfg!(all(target_os = "linux", feature = "openvino")) {
+        patch_openvino_1_29_headers(&onnx_dir);
+    }
+
     let mut build_commands = vec![
         "--config".to_string(),
         get_build_config().to_string(),
@@ -416,6 +466,7 @@ fn build_onnx(out_dir: &Path) {
         "--parallel".to_string(),
         num_cpus::get_physical().to_string(),
         "--compile_no_warning_as_error".to_string(),
+        "--skip_submodule_sync".to_string(),
         "--skip_tests".to_string(),
         "--no_telemetry".to_string(),
         "--enable_lto".to_string(),
@@ -443,6 +494,8 @@ fn build_onnx(out_dir: &Path) {
     } else if cfg!(target_os = "macos") {
         // Enable Core ML on macOS
         build_commands.push("--use_coreml".to_string());
+    } else if cfg!(all(target_os = "linux", feature = "openvino")) {
+        build_commands.extend(["--use_openvino".to_string(), "GPU".to_string()]);
     }
 
     build_warning!("Running ONNX Runtime build script");
@@ -457,5 +510,39 @@ fn build_onnx(out_dir: &Path) {
         panic!("ONNX Runtime build failed");
     } else {
         build_warning!("ONNX Runtime build completed successfully");
+    }
+}
+
+fn patch_openvino_1_29_headers(onnx_dir: &Path) {
+    // ONNX Runtime 1.29's OpenVINO provider omits two required standard-library
+    // headers. Keep this source-build path aligned with the compatibility patch
+    // in Dockerfile.openvino.
+    for (relative_path, header) in [
+        (
+            "onnxruntime/core/providers/openvino/backend_manager.cc",
+            "charconv",
+        ),
+        (
+            "onnxruntime/core/providers/openvino/exceptions.h",
+            "charconv",
+        ),
+        (
+            "onnxruntime/core/providers/openvino/ov_bin_manager.h",
+            "optional",
+        ),
+        (
+            "onnxruntime/core/providers/openvino/ov_shared_context.h",
+            "optional",
+        ),
+    ] {
+        let path = onnx_dir.join(relative_path);
+        let include = format!("#include <{header}>");
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("Failed to read {}: {error}", path.display()));
+        if source.lines().any(|line| line.trim() == include) {
+            continue;
+        }
+        std::fs::write(&path, format!("{include}\n{source}"))
+            .unwrap_or_else(|error| panic!("Failed to patch {}: {error}", path.display()));
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -49,6 +49,24 @@ fn main() {
     }
     let (out_dir, output_dir) = cargo_output_dirs(&out_dir);
 
+    println!("cargo:rerun-if-env-changed=BLUE_ONYX_ORT_LIB_DIR");
+    if let Ok(prebuilt_dir) = env::var("BLUE_ONYX_ORT_LIB_DIR") {
+        let library = Path::new(&prebuilt_dir).join("libonnxruntime.so");
+        if !library.is_file() {
+            build_error!("Prebuilt ONNX Runtime library not found: {:?}", library);
+            panic!("Prebuilt ONNX Runtime setup incomplete");
+        }
+
+        build_warning!("Using prebuilt ONNX Runtime from {}", prebuilt_dir);
+        if !output_dir.exists() {
+            std::fs::create_dir_all(&output_dir).expect("Failed to create output directory");
+        }
+        std::fs::copy(&library, output_dir.join("libonnxruntime.so"))
+            .expect("Failed to copy prebuilt ONNX Runtime library to output directory");
+        println!("cargo:rustc-env=ORT_DYLIB_PATH=libonnxruntime.so");
+        return;
+    }
+
     check_and_download_onnx_source(&out_dir);
     if cfg!(windows) {
         check_and_download_directml(&out_dir);

--- a/build.rs
+++ b/build.rs
@@ -48,11 +48,18 @@ fn main() {
         return;
     }
     let (out_dir, output_dir) = cargo_output_dirs(&out_dir);
+    let shared_lib_name = if cfg!(windows) {
+        "onnxruntime.dll"
+    } else if cfg!(target_os = "macos") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    };
 
     println!("cargo:rerun-if-env-changed=BLUE_ONYX_ORT_LIB_DIR");
     if let Ok(prebuilt_dir) = env::var("BLUE_ONYX_ORT_LIB_DIR") {
         let prebuilt_dir = Path::new(&prebuilt_dir);
-        let library = prebuilt_dir.join("libonnxruntime.so");
+        let library = prebuilt_dir.join(shared_lib_name);
         if !library.is_file() {
             build_error!("Prebuilt ONNX Runtime library not found: {:?}", library);
             panic!("Prebuilt ONNX Runtime setup incomplete");
@@ -77,7 +84,7 @@ fn main() {
             std::fs::create_dir_all(&output_dir).expect("Failed to create output directory");
         }
         copy_onnxruntime_libraries(prebuilt_dir, &output_dir);
-        println!("cargo:rustc-env=ORT_DYLIB_PATH=libonnxruntime.so");
+        println!("cargo:rustc-env=ORT_DYLIB_PATH={shared_lib_name}");
         return;
     }
 
@@ -87,14 +94,6 @@ fn main() {
     }
 
     let build_dir = out_dir.join(ONNX_SOURCE.0).join("build");
-
-    let shared_lib_name = if cfg!(windows) {
-        "onnxruntime.dll"
-    } else if cfg!(target_os = "macos") {
-        "libonnxruntime.dylib"
-    } else {
-        "libonnxruntime.so"
-    };
 
     let expected_binary = build_dir
         .join(if cfg!(windows) {

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -6,20 +6,14 @@ services:
     ports:
       - "32168:32168"
     volumes:
-      - ./models:/app/models
       - ./config:/app/config
       - ./logs:/app/logs
-      - ./processed_images:/app/processed_images
     environment:
       - RUST_LOG=info
     devices:
       - /dev/dri/renderD128:/dev/dri/renderD128
     command: >
       --port 32168
-      --model /app/IPcam-general.onnx
-      --object-detection-model-type yolo5
-      --object-classes /app/IPcam-general.yaml
-      --confidence-threshold 0.5
       --log-level info
       --log-path /app/logs
       --save-stats-path /app/logs

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+services:
+  blue-onyx:
+    image: blue-onyx-openvino:0.8.0-openvino2
+    container_name: blue-onyx
+    ports:
+      - "32168:32168"
+    volumes:
+      - ./models:/app/models
+      - ./config:/app/config
+      - ./logs:/app/logs
+      - ./processed_images:/app/processed_images
+    environment:
+      - RUST_LOG=info
+    devices:
+      - /dev/dri/renderD128:/dev/dri/renderD128
+    command: >
+      --port 32168
+      --model /app/IPcam-general.onnx
+      --object-detection-model-type yolo5
+      --object-classes /app/IPcam-general.yaml
+      --confidence-threshold 0.5
+      --log-level info
+      --log-path /app/logs
+      --save-stats-path /app/logs
+      --request-timeout 30
+    restart: unless-stopped
+    healthcheck:
+      disable: true

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - "32168:32168"
     volumes:
-      - ./config:/app/config
-      - ./logs:/app/logs
+      - ../config:/app/config
+      - ../logs:/app/logs
     environment:
       - RUST_LOG=info
     devices:

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1124,6 +1124,8 @@ pub enum ExecutionProvider {
     CPU,
     #[cfg(windows)]
     DirectML(usize), // GPU index
+    #[cfg(target_os = "macos")]
+    CoreML,
     #[cfg(all(target_os = "linux", feature = "openvino"))]
     OpenVINO(usize), // GPU index
 }

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -15,7 +15,7 @@ use ndarray::{Array, ArrayView, Axis, s};
 use ort::ep::DirectML;
 #[cfg(target_os = "macos")]
 use ort::ep::{CoreML, coreml::ModelFormat};
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "openvino"))]
 use ort::ep::OpenVINO;
 use ort::{
     inputs,
@@ -987,15 +987,19 @@ fn initialize_onnx(onnx_config: &OnnxConfig) -> InitializeOnnxResult {
             (1, 1)
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(all(target_os = "linux", feature = "openvino"))]
         {
             let device = format!("GPU.{}", onnx_config.gpu_index);
             info!(device, "Configuring OpenVINO GPU execution provider");
-            let provider = OpenVINO::default()
+            let mut provider = OpenVINO::default()
                 .with_device_type(&device)
                 .with_precision("FP16")
-                .with_num_streams(1)
-                .with_cache_dir("/app/config/openvino-cache")
+                .with_num_streams(1);
+            if let Ok(cache_dir) = std::env::var("BLUE_ONYX_OPENVINO_CACHE_DIR") {
+                info!(cache_dir, "Enabling the OpenVINO compiled-model cache");
+                provider = provider.with_cache_dir(cache_dir);
+            }
+            let provider = provider
                 .build()
                 .error_on_failure();
             providers.push(provider);
@@ -1003,7 +1007,11 @@ fn initialize_onnx(onnx_config: &OnnxConfig) -> InitializeOnnxResult {
             (1, 1)
         }
 
-        #[cfg(not(any(windows, target_os = "linux")))]
+        #[cfg(not(any(
+            windows,
+            target_os = "macos",
+            all(target_os = "linux", feature = "openvino")
+        )))]
         {
             let num_intra_threads = onnx_config.intra_threads.min(16);
             let num_inter_threads = onnx_config.inter_threads.min(16);
@@ -1058,7 +1066,7 @@ fn initialize_onnx(onnx_config: &OnnxConfig) -> InitializeOnnxResult {
         DeviceType::GPU => EndpointProvider::DirectML,
         #[cfg(target_os = "macos")]
         DeviceType::GPU => EndpointProvider::CoreML,
-        #[cfg(target_os = "linux")]
+        #[cfg(all(target_os = "linux", feature = "openvino"))]
         DeviceType::GPU => EndpointProvider::OpenVINO,
         _ => EndpointProvider::CPU,
     };
@@ -1079,7 +1087,7 @@ pub enum EndpointProvider {
     DirectML,
     #[cfg(target_os = "macos")]
     CoreML,
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "openvino"))]
     OpenVINO,
 }
 
@@ -1091,7 +1099,7 @@ impl std::fmt::Display for EndpointProvider {
             EndpointProvider::DirectML => write!(f, "DirectML"),
             #[cfg(target_os = "macos")]
             EndpointProvider::CoreML => write!(f, "CoreML"),
-            #[cfg(target_os = "linux")]
+            #[cfg(all(target_os = "linux", feature = "openvino"))]
             EndpointProvider::OpenVINO => write!(f, "OpenVINO"),
         }
     }
@@ -1118,6 +1126,6 @@ pub enum ExecutionProvider {
     CPU,
     #[cfg(windows)]
     DirectML(usize), // GPU index
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "openvino"))]
     OpenVINO(usize), // GPU index
 }

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -15,6 +15,8 @@ use ndarray::{Array, ArrayView, Axis, s};
 use ort::ep::DirectML;
 #[cfg(target_os = "macos")]
 use ort::ep::{CoreML, coreml::ModelFormat};
+#[cfg(target_os = "linux")]
+use ort::ep::OpenVINO;
 use ort::{
     inputs,
     session::{Session, SessionInputs, SessionOutputs},
@@ -985,20 +987,27 @@ fn initialize_onnx(onnx_config: &OnnxConfig) -> InitializeOnnxResult {
             (1, 1)
         }
 
-        #[cfg(all(not(windows), not(target_os = "macos")))]
+        #[cfg(target_os = "linux")]
         {
-            let num_intra_threads = onnx_config
-                .intra_threads
-                .min(num_cpus::get_physical() - 1)
-                .min(16);
-            let num_inter_threads = onnx_config
-                .inter_threads
-                .min(num_cpus::get_physical() - 1)
-                .min(16);
-            warn!(
-                "GPU acceleration not available on this platform, using CPU for inference with {} intra and {} inter threads",
-                num_intra_threads, num_inter_threads
-            );
+            let device = format!("GPU.{}", onnx_config.gpu_index);
+            info!(device, "Configuring OpenVINO GPU execution provider");
+            let provider = OpenVINO::default()
+                .with_device_type(&device)
+                .with_precision("FP16")
+                .with_num_streams(1)
+                .with_cache_dir("/app/config/openvino-cache")
+                .build()
+                .error_on_failure();
+            providers.push(provider);
+            device_type = DeviceType::GPU;
+            (1, 1)
+        }
+
+        #[cfg(not(any(windows, target_os = "linux")))]
+        {
+            let num_intra_threads = onnx_config.intra_threads.min(16);
+            let num_inter_threads = onnx_config.inter_threads.min(16);
+            warn!("GPU acceleration is unavailable; using the CPU execution provider");
             (num_intra_threads, num_inter_threads)
         }
     };
@@ -1049,6 +1058,8 @@ fn initialize_onnx(onnx_config: &OnnxConfig) -> InitializeOnnxResult {
         DeviceType::GPU => EndpointProvider::DirectML,
         #[cfg(target_os = "macos")]
         DeviceType::GPU => EndpointProvider::CoreML,
+        #[cfg(target_os = "linux")]
+        DeviceType::GPU => EndpointProvider::OpenVINO,
         _ => EndpointProvider::CPU,
     };
     Ok((
@@ -1068,6 +1079,8 @@ pub enum EndpointProvider {
     DirectML,
     #[cfg(target_os = "macos")]
     CoreML,
+    #[cfg(target_os = "linux")]
+    OpenVINO,
 }
 
 impl std::fmt::Display for EndpointProvider {
@@ -1078,6 +1091,8 @@ impl std::fmt::Display for EndpointProvider {
             EndpointProvider::DirectML => write!(f, "DirectML"),
             #[cfg(target_os = "macos")]
             EndpointProvider::CoreML => write!(f, "CoreML"),
+            #[cfg(target_os = "linux")]
+            EndpointProvider::OpenVINO => write!(f, "OpenVINO"),
         }
     }
 }
@@ -1103,4 +1118,6 @@ pub enum ExecutionProvider {
     CPU,
     #[cfg(windows)]
     DirectML(usize), // GPU index
+    #[cfg(target_os = "linux")]
+    OpenVINO(usize), // GPU index
 }

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -13,10 +13,10 @@ use bytes::Bytes;
 use ndarray::{Array, ArrayView, Axis, s};
 #[cfg(windows)]
 use ort::ep::DirectML;
-#[cfg(target_os = "macos")]
-use ort::ep::{CoreML, coreml::ModelFormat};
 #[cfg(all(target_os = "linux", feature = "openvino"))]
 use ort::ep::OpenVINO;
+#[cfg(target_os = "macos")]
+use ort::ep::{CoreML, coreml::ModelFormat};
 use ort::{
     inputs,
     session::{Session, SessionInputs, SessionOutputs},

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -999,9 +999,7 @@ fn initialize_onnx(onnx_config: &OnnxConfig) -> InitializeOnnxResult {
                 info!(cache_dir, "Enabling the OpenVINO compiled-model cache");
                 provider = provider.with_cache_dir(cache_dir);
             }
-            let provider = provider
-                .build()
-                .error_on_failure();
+            let provider = provider.build().error_on_failure();
             providers.push(provider);
             device_type = DeviceType::GPU;
             (1, 1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,10 @@ pub fn log_available_gpus() {
     #[cfg(target_os = "macos")]
     info!("CoreML is available for hardware-accelerated inference");
 
-    #[cfg(all(not(windows), not(target_os = "macos")))]
+    #[cfg(target_os = "linux")]
+    info!("OpenVINO GPU inference is enabled on Linux");
+
+    #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
     info!("GPU acceleration not available on this platform - only CPU inference will be supported");
 
     // Log available GPU devices

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,10 +117,14 @@ pub fn log_available_gpus() {
     #[cfg(target_os = "macos")]
     info!("CoreML is available for hardware-accelerated inference");
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "openvino"))]
     info!("OpenVINO GPU inference is enabled on Linux");
 
-    #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+    #[cfg(not(any(
+        windows,
+        target_os = "macos",
+        all(target_os = "linux", feature = "openvino")
+    )))]
     info!("GPU acceleration not available on this platform - only CPU inference will be supported");
 
     // Log available GPU devices

--- a/src/server.rs
+++ b/src/server.rs
@@ -878,6 +878,8 @@ impl Metrics {
             ExecutionProvider::CPU => "CPU".to_string(),
             #[cfg(windows)]
             ExecutionProvider::DirectML(index) => format!("DirectML(GPU {index})"),
+            #[cfg(target_os = "linux")]
+            ExecutionProvider::OpenVINO(index) => format!("OpenVINO(GPU {index})"),
         };
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -878,7 +878,7 @@ impl Metrics {
             ExecutionProvider::CPU => "CPU".to_string(),
             #[cfg(windows)]
             ExecutionProvider::DirectML(index) => format!("DirectML(GPU {index})"),
-            #[cfg(target_os = "linux")]
+            #[cfg(all(target_os = "linux", feature = "openvino"))]
             ExecutionProvider::OpenVINO(index) => format!("OpenVINO(GPU {index})"),
         };
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -878,6 +878,8 @@ impl Metrics {
             ExecutionProvider::CPU => "CPU".to_string(),
             #[cfg(windows)]
             ExecutionProvider::DirectML(index) => format!("DirectML(GPU {index})"),
+            #[cfg(target_os = "macos")]
+            ExecutionProvider::CoreML => "CoreML".to_string(),
             #[cfg(all(target_os = "linux", feature = "openvino"))]
             ExecutionProvider::OpenVINO(index) => format!("OpenVINO(GPU {index})"),
         };

--- a/src/startup_coordinator.rs
+++ b/src/startup_coordinator.rs
@@ -72,13 +72,13 @@ fn startup_worker_thread(
                         detector_config.object_detection_onnx_config.gpu_index as usize,
                     )
                 }
-                #[cfg(target_os = "linux")]
+                #[cfg(all(target_os = "linux", feature = "openvino"))]
                 {
                     ExecutionProvider::OpenVINO(
                         detector_config.object_detection_onnx_config.gpu_index as usize,
                     )
                 }
-                #[cfg(not(any(windows, target_os = "linux")))]
+                #[cfg(not(any(windows, all(target_os = "linux", feature = "openvino"))))]
                 {
                     ExecutionProvider::CPU
                 }

--- a/src/startup_coordinator.rs
+++ b/src/startup_coordinator.rs
@@ -72,7 +72,13 @@ fn startup_worker_thread(
                         detector_config.object_detection_onnx_config.gpu_index as usize,
                     )
                 }
-                #[cfg(not(windows))]
+                #[cfg(target_os = "linux")]
+                {
+                    ExecutionProvider::OpenVINO(
+                        detector_config.object_detection_onnx_config.gpu_index as usize,
+                    )
+                }
+                #[cfg(not(any(windows, target_os = "linux")))]
                 {
                     ExecutionProvider::CPU
                 }

--- a/src/startup_coordinator.rs
+++ b/src/startup_coordinator.rs
@@ -72,13 +72,21 @@ fn startup_worker_thread(
                         detector_config.object_detection_onnx_config.gpu_index as usize,
                     )
                 }
+                #[cfg(target_os = "macos")]
+                {
+                    ExecutionProvider::CoreML
+                }
                 #[cfg(all(target_os = "linux", feature = "openvino"))]
                 {
                     ExecutionProvider::OpenVINO(
                         detector_config.object_detection_onnx_config.gpu_index as usize,
                     )
                 }
-                #[cfg(not(any(windows, all(target_os = "linux", feature = "openvino"))))]
+                #[cfg(not(any(
+                    windows,
+                    target_os = "macos",
+                    all(target_os = "linux", feature = "openvino")
+                )))]
                 {
                     ExecutionProvider::CPU
                 }


### PR DESCRIPTION
## Summary

- add an opt-in `openvino` Cargo feature for Linux Intel GPU inference
- configure the ONNX Runtime OpenVINO execution provider with `GPU.<index>`, FP16 precision, and one latency-focused stream
- expose the active OpenVINO provider through service metrics and API responses
- support an optional compiled-model cache through `BLUE_ONYX_OPENVINO_CACHE_DIR`
- add a reproducible OpenVINO Docker image, Compose example, and Linux setup documentation

## Why

Blue Onyx already exposes `force_cpu` and `gpu_index`, but GPU inference was implemented only for Windows through DirectML. Linux builds therefore fell back to CPU even when an Intel render device was available.

This change provides the missing Linux execution provider while keeping it opt-in. Builds without the `openvino` feature retain the existing CPU behavior and do not require an OpenVINO-enabled ONNX Runtime library.

## Validation

- built the complete image with `docker build -f Dockerfile.openvino -t blue-onyx-openvino:pr-test .`
- initialized `OpenVINO(0)` on an Intel N150 iGPU through `/dev/dri/renderD128`
- completed a real detection request with HTTP 200, the expected bicycle/dog/car predictions, `executionProvider: OpenVINO`, and `canUseGPU: true`
- compiled the default Linux path with `cargo check --locked --release --no-default-features --bin blue_onyx`
- validated the included Compose definition with `docker compose config`
- observed approximately 54 ms average inference with the IP camera model in sustained deployment, compared with approximately 219 ms on the previous CPU path, with zero dropped requests
