### PR TITLE
Fix Hugging Face model downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: build-test-cpu
     env:
       RUST_BACKTRACE: 1
-      RUSTFLAGS: -C target-cpu=native -D warnings
+      RUSTFLAGS: ${{ matrix.os == 'macos-latest' && '-D warnings' || '-C target-cpu=native -D warnings' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1970,11 +1971,15 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1984,6 +1989,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2081,6 +2087,7 @@ checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3003,6 +3010,15 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,10 @@ chrono = { version = "0", default-features = false, features = ["now"] }
 crossbeam = { version = "0", default-features = false, features = ["std"] }
 fast_image_resize = { version = "5", default-features = false }
 futures = { version = "0", default-features = false }
-hf-hub = { version = "0", default-features = false, features = ["tokio"] }
+hf-hub = { version = "0", default-features = false, features = [
+    "rustls-tls",
+    "tokio",
+] }
 image = { version = "0", default-features = false }
 imageproc = { version = "0", default-features = false, features = ["text"] }
 indicatif = { version = "0", default-features = false }

--- a/src/server.rs
+++ b/src/server.rs
@@ -108,7 +108,7 @@ pub async fn run_server(
                 }
             }
             Ok(InitResult::Failed(error)) => {
-                error!(error = %error, "Detector initialization failed");
+                error!(error = ?error, "Detector initialization failed");
                 let mut detector_ready = state_clone.detector_ready.lock().await;
                 *detector_ready = DetectorReady::Failed(error);
             }

--- a/src/startup_coordinator.rs
+++ b/src/startup_coordinator.rs
@@ -110,7 +110,7 @@ fn startup_worker_thread(
             // The server now owns the sender and can communicate with the detector
         }
         Err(e) => {
-            error!(error = %e, "Startup worker thread: Detector initialization failed");
+            error!(error = ?e, "Startup worker thread: Detector initialization failed");
             let result = InitResult::Failed(e.to_string());
             if init_sender.send(result).is_err() {
                 error!("Startup worker thread: Failed to send failure result to server");


### PR DESCRIPTION
## Summary

- enable the `rustls-tls` backend for `hf-hub` downloads
- preserve nested initialization errors in startup logs

## Root cause

After the dependency update, `hf-hub` 0.5 was built with `default-features = false` and only the `tokio` feature. That enables Reqwest but no TLS backend, so every `https://huggingface.co/...` request failed immediately with `error sending request`.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --all-targets --locked` (5 passed)
- cold-downloaded `rf-detr-n.onnx` (114.82 MiB) and `rf-detr-n.yaml`
- loaded the downloaded model and completed RF-DETR inference through CoreML